### PR TITLE
Fix selfkillother string format

### DIFF
--- a/Addons/AdvancedVanillaCombatLog/core.lua
+++ b/Addons/AdvancedVanillaCombatLog/core.lua
@@ -622,7 +622,7 @@ function RPLL:fix_combat_log_strings()
     PROCRESISTOTHERSELF = player_name .. " resists %s" .. " 's %s."
     PROCRESISTSELFOTHER = "%s resists " .. player_name .. " 's %s."
     PROCRESISTSELFSELF = player_name .. " resists " .. player_name .. " 's %s."
-    SELFKILLOTHER = player_name .. " slays %s!"
+    SELFKILLOTHER = "%s is slain by " .. player_name .."!"
     SIMPLECASTOTHERSELF = "%s casts %s on " .. player_name .. "."
     SIMPLECASTSELFOTHER = player_name .. " casts %s on %s."
     SIMPLECASTSELFSELF = player_name .. " casts %s on " .. player_name .. "."


### PR DESCRIPTION
Changed formatting to match PARTYKILLOTHER
PARTYKILLOTHER = "%s is slain by %s!"
source: https://github.com/MOUZU/Blizzard-WoW-Interface/blob/d162a4c0d198a4381b5b6573d975635ed7316702/1.12.1/FrameXML/GlobalStrings.lua#L2988

![image](https://github.com/Legacy-Players/LegacyPlayersV4/assets/111737968/cc40c5db-63b4-4a82-aeeb-db65c7693d65)
The person doing the logging is on the right and the formatting for him is different. This changes it to be like his party members on the left.